### PR TITLE
Update fly.toml to enable access

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,12 +1,12 @@
-# fly.toml app configuration file generated for gitea-server-aarulabs on 2025-05-23T20:22:57Z
-#
+# fly.toml app configuration file for gitea-server-aarulabs
+
 app = "gitea-server-aarulabs"
-primary_region = 'fra'
+primary_region = "fra"
 
 kill_timeout = 5
 
 [build]
-  image = "gitea/gitea:latest" # latest is the most recent stable release
+  image = "gitea/gitea:latest" # Use the latest stable release of Gitea
 
 [env]
   GITEA__database__DB_TYPE = "sqlite3"
@@ -17,46 +17,47 @@ kill_timeout = 5
   GITEA__server__HTTP_PORT = "3000"
   GITEA__security__INSTALL_LOCK = "true"
 
-# persist data
+# Persistent volume mount
 [[mounts]]
-  destination = "/data"
   source = "gitea_data"
+  destination = "/data"
 
-# ssh traffic
+# SSH (for Git over SSH, optional)
 [[services]]
   internal_port = 22
   protocol = "tcp"
   [[services.ports]]
     port = 22
 
-# for http->https redirect
+# HTTP to HTTPS redirect
 [[services]]
   internal_port = 80
   protocol = "tcp"
-
   [[services.ports]]
-    handlers = ["http"]
     port = 80
+    handlers = ["http"]
 
-# https traffic
+# HTTPS traffic (serving Gitea UI)
 [[services]]
   internal_port = 3000
   protocol = "tcp"
-
   [[services.ports]]
-    handlers = ["tls", "http"]
     port = 443
+    handlers = ["tls", "http"]
 
-[http_service]
-  internal_port = 8080
-  force_https = true
-  auto_stop_machines = 'stop'
-  auto_start_machines = true
-  min_machines_running = 0
-  processes = ['app']
+# Optional HTTP health check
+[checks]
+  [checks.http_check]
+    type = "http"
+    interval = "30s"
+    timeout = "5s"
+    method = "get"
+    path = "/"
+    protocol = "https"
+    port = 3000
 
 [[vm]]
-  memory = '1gb'
-  cpu_kind = 'shared'
+  memory = "1gb"
+  cpu_kind = "shared"
   cpus = 1
   memory_mb = 1024


### PR DESCRIPTION
The [http_service] section removed (since it conflicts with the manual [[services]] config).

An optional HTTP health check added.